### PR TITLE
Simplified test code

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -98,5 +98,6 @@ dependencies {
     testImplementation deps.kluent
     testImplementation deps.hikari
     testImplementation deps.h2
+    testImplementation deps.koin.test
     testRuntimeOnly deps.junit.jupiterEngine
 }

--- a/src/test/kotlin/mobi/waterdog/eventbus/EventBusTest.kt
+++ b/src/test/kotlin/mobi/waterdog/eventbus/EventBusTest.kt
@@ -9,55 +9,40 @@ import kotlinx.coroutines.experimental.runBlocking
 import mobi.waterdog.eventbus.model.EventInput
 import org.amshove.kluent.`should be true`
 import org.amshove.kluent.`should equal`
-import org.junit.jupiter.api.AfterEach
-import org.junit.jupiter.api.BeforeAll
-import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.*
 import org.koin.dsl.module.module
-import org.koin.standalone.KoinComponent
-import org.koin.standalone.StandAloneContext
+import org.koin.standalone.StandAloneContext.startKoin
+import org.koin.standalone.StandAloneContext.stopKoin
 import org.koin.standalone.inject
+import org.koin.test.KoinTest
 import javax.sql.DataSource
 
-val databaseModule = module {
-    single<DataSource> {
-        HikariDataSource(HikariConfig().apply {
-            driverClassName = "org.h2.Driver"
-            jdbcUrl = "jdbc:h2:mem:test"
-            maximumPoolSize = 5
-            isAutoCommit = false
-            transactionIsolation = "TRANSACTION_REPEATABLE_READ"
-            validate()
-        })
-    }
-    single<CoroutineDispatcher> {
-        newFixedThreadPoolContext(5, "database-pool")
-    }
-}
-
-class EventBusTest : KoinComponent {
-
-    companion object {
-        var initDone = false
-
-        @BeforeAll
-        fun initKoin() {
-            StandAloneContext.startKoin(listOf())
-        }
-    }
-
-    init {
-        if (!initDone) {
-            StandAloneContext.loadKoinModules(listOf(databaseModule, getModule()))
-            initDone = true
-        }
+class EventBusTest : KoinTest {
+    @Suppress("unused")
+    @BeforeAll
+    fun beforeClass() {
+        startKoin(listOf(module {
+            single<DataSource> {
+                HikariDataSource(HikariConfig().apply {
+                    driverClassName = "org.h2.Driver"
+                    jdbcUrl = "jdbc:h2:mem:test"
+                    maximumPoolSize = 5
+                    isAutoCommit = false
+                    transactionIsolation = "TRANSACTION_REPEATABLE_READ"
+                    validate()
+                })
+            }
+            single<CoroutineDispatcher> {
+                newFixedThreadPoolContext(5, "database-pool")
+            }
+        }, getModule()))
     }
 
     private val targetTopic1 = "MyTopic1"
     private val targetTopic2 = "MyTopic2"
-    private val ebf: EventBusProvider by inject()
-    private lateinit var eventProducer: EventProducer
-    private lateinit var eventConsumer: EventConsumer
+    private val ebf by inject<EventBusProvider>()
+    private val eventProducer: EventProducer by lazy { ebf.getProducer() }
+    private val eventConsumer: EventConsumer by lazy { ebf.getConsumer() }
 
     @AfterEach
     fun cleanup() {
@@ -73,8 +58,6 @@ class EventBusTest : KoinComponent {
     @BeforeEach
     fun setup() {
         ebf.setup()
-        eventProducer = ebf.getProducer()
-        eventConsumer = ebf.getConsumer()
     }
 
     @Test
@@ -88,10 +71,10 @@ class EventBusTest : KoinComponent {
 
         repeat(n) {
             val event = EventInput(
-                targetTopic1,
-                "Sample",
-                "application/json",
-                jsonMsg.toByteArray()
+                    targetTopic1,
+                    "Sample",
+                    "application/json",
+                    jsonMsg.toByteArray()
             )
             eventProducer.send(event)
         }
@@ -103,21 +86,21 @@ class EventBusTest : KoinComponent {
         var count = 0
         val n = 10
         eventConsumer.stream(targetTopic2)
-            .filter { it.msgType == "Sample" && it.mimeType == "application/json" }
-            .map { String(it.payload) }
-            .subscribe {
-                it `should equal` jsonMsg
-                count += 1
-            }
+                .filter { it.msgType == "Sample" && it.mimeType == "application/json" }
+                .map { String(it.payload) }
+                .subscribe {
+                    it `should equal` jsonMsg
+                    count += 1
+                }
         eventConsumer.listSubscribers(targetTopic2).size `should equal` 1
 
         runBlocking {
             repeat(n) {
                 val event = EventInput(
-                    targetTopic2,
-                    "Sample",
-                    "application/json",
-                    jsonMsg.toByteArray()
+                        targetTopic2,
+                        "Sample",
+                        "application/json",
+                        jsonMsg.toByteArray()
                 )
                 val result = eventProducer.sendAndWaitForAck(event)
                 result.`should be true`()
@@ -126,5 +109,11 @@ class EventBusTest : KoinComponent {
         }
 
         count `should equal` n
+    }
+
+    @Suppress("unused")
+    @AfterAll
+    fun afterAll() {
+        stopKoin()
     }
 }

--- a/src/test/resources/junit-platform.properties
+++ b/src/test/resources/junit-platform.properties
@@ -1,0 +1,1 @@
+junit.jupiter.testinstance.lifecycle.default = per_class


### PR DESCRIPTION
Setting test instance lifecycle to per_class using a properties file removes the need for static method for `BeforeAll` and `AfterAll` annotations.