### PR TITLE
Force the events to be sent in ascending order

### DIFF
--- a/src/main/kotlin/mobi/waterdog/eventbus/EventBusFactory.kt
+++ b/src/main/kotlin/mobi/waterdog/eventbus/EventBusFactory.kt
@@ -31,8 +31,7 @@ internal class EventBusFactory(private val localEventCache: LocalEventCache) : E
 
     override fun getProducer(): EventProducer {
         try {
-            val delay = props?.get("sync.delayMillis")?.toString()?.toLong() ?: 100
-            producerInstance = producerInstance ?: PersistentEventWriter(localEventCache, engine!!, delay)
+            producerInstance = producerInstance ?: PersistentEventWriter(localEventCache, engine!!)
             return producerInstance!!
         } catch (npe: NullPointerException) {
             throw IllegalStateException("Please call setup")

--- a/src/main/kotlin/mobi/waterdog/eventbus/EventProducer.kt
+++ b/src/main/kotlin/mobi/waterdog/eventbus/EventProducer.kt
@@ -3,6 +3,6 @@ package mobi.waterdog.eventbus
 import mobi.waterdog.eventbus.model.EventInput
 
 interface EventProducer {
-    fun send(eventInput: EventInput)
-    suspend fun sendAndWaitForAck(eventInput: EventInput): Boolean
+    fun sendAsync(eventInput: EventInput)
+    fun send(eventInput: EventInput): Boolean
 }

--- a/src/main/kotlin/mobi/waterdog/eventbus/engine/kafka/KafkaEngine.kt
+++ b/src/main/kotlin/mobi/waterdog/eventbus/engine/kafka/KafkaEngine.kt
@@ -18,7 +18,7 @@ internal class KafkaEngine(producerConfigs: Properties) : EventEngine {
     }
 
     override fun send(event: Event) {
-        log.debug("Forwarding event ${event.topic}/${event.uuid} to kafka")
+        log.trace("Forwarding event ${event.topic}/${event.uuid} to kafka")
         producer.send(ProducerRecord(event.topic, serializeEvent(event)))
     }
 

--- a/src/main/kotlin/mobi/waterdog/eventbus/engine/kafka/KafkaEvent.kt
+++ b/src/main/kotlin/mobi/waterdog/eventbus/engine/kafka/KafkaEvent.kt
@@ -5,19 +5,19 @@ import mobi.waterdog.eventbus.model.EventOutput
 import java.time.Instant
 
 internal class KafkaEvent(
-    val topic: String,
-    val uuid: String,
-    val timestamp: String,
-    val msgType: String,
-    val mimeType: String,
-    val payload: String
+    private val topic: String,
+    private val uuid: String,
+    private val timestamp: String,
+    private val msgType: String,
+    private val mimeType: String,
+    private val payload: String
 ) {
     companion object {
         fun build(event: Event): KafkaEvent {
             return KafkaEvent(
                 event.topic,
                 event.uuid,
-                event.timestamp.toString(),
+                Instant.now().toString(),
                 event.msgType,
                 event.mimeType,
                 String(event.payload)

--- a/src/main/kotlin/mobi/waterdog/eventbus/engine/local/LocalEventEngine.kt
+++ b/src/main/kotlin/mobi/waterdog/eventbus/engine/local/LocalEventEngine.kt
@@ -7,11 +7,12 @@ import mobi.waterdog.eventbus.EventConsumer
 import mobi.waterdog.eventbus.engine.EventEngine
 import mobi.waterdog.eventbus.model.Event
 import mobi.waterdog.eventbus.model.EventOutput
+import java.time.Instant
 import java.util.concurrent.ConcurrentHashMap
 
 internal fun Event.toOutputEvent(): EventOutput = EventOutput(
     this.uuid,
-    this.timestamp,
+    Instant.now(),
     this.topic,
     this.msgType,
     this.mimeType,

--- a/src/main/kotlin/mobi/waterdog/eventbus/model/Event.kt
+++ b/src/main/kotlin/mobi/waterdog/eventbus/model/Event.kt
@@ -7,7 +7,8 @@ internal data class Event(
     val delivered: Boolean,
     val topic: String,
     val uuid: String,
-    val timestamp: Instant,
+    val storeTimestamp: Instant,
+    val sentTimestamp: Instant?,
     val msgType: String,
     val mimeType: String,
     val payload: ByteArray
@@ -22,7 +23,8 @@ internal data class Event(
         if (delivered != other.delivered) return false
         if (topic != other.topic) return false
         if (uuid != other.uuid) return false
-        if (timestamp != other.timestamp) return false
+        if (storeTimestamp != other.storeTimestamp) return false
+        if (sentTimestamp != other.sentTimestamp) return false
         if (msgType != other.msgType) return false
         if (mimeType != other.mimeType) return false
 
@@ -34,7 +36,12 @@ internal data class Event(
         result = 31 * result + delivered.hashCode()
         result = 31 * result + topic.hashCode()
         result = 31 * result + uuid.hashCode()
-        result = 31 * result + timestamp.hashCode()
+        result = 31 * result + storeTimestamp.hashCode()
+
+        if (sentTimestamp != null) {
+            result = 31 * result + sentTimestamp.hashCode()
+        }
+
         result = 31 * result + msgType.hashCode()
         result = 31 * result + mimeType.hashCode()
         return result

--- a/src/main/kotlin/mobi/waterdog/eventbus/persistence/LocalEventCache.kt
+++ b/src/main/kotlin/mobi/waterdog/eventbus/persistence/LocalEventCache.kt
@@ -2,9 +2,10 @@ package mobi.waterdog.eventbus.persistence
 
 import mobi.waterdog.eventbus.model.Event
 import mobi.waterdog.eventbus.model.EventInput
+import java.util.concurrent.BlockingQueue
 
 internal interface LocalEventCache {
     suspend fun storeEvent(eventInput: EventInput): Event
-    suspend fun markAsDelivered(eventId: Long)
-    suspend fun getAllUndelivered(): List<Event>
+    fun markAsDelivered(eventId: Long)
+    fun getPendingEventQueue(): BlockingQueue<Event>
 }

--- a/src/main/kotlin/mobi/waterdog/eventbus/persistence/PersistentEventWriter.kt
+++ b/src/main/kotlin/mobi/waterdog/eventbus/persistence/PersistentEventWriter.kt
@@ -1,34 +1,38 @@
 package mobi.waterdog.eventbus.persistence
 
 import kotlinx.coroutines.experimental.GlobalScope
-import kotlinx.coroutines.experimental.delay
 import kotlinx.coroutines.experimental.launch
+import kotlinx.coroutines.experimental.runBlocking
 import mobi.waterdog.eventbus.EventProducer
 import mobi.waterdog.eventbus.engine.EventEngine
 import mobi.waterdog.eventbus.model.EventInput
 import org.slf4j.LoggerFactory
+import kotlin.concurrent.thread
 
 internal class PersistentEventWriter(
     private val localEventCache: LocalEventCache,
-    private val eventEngine: EventEngine,
-    private val loopDelay: Long = 1000
+    private val eventEngine: EventEngine
 ) : EventProducer {
 
     private val log = LoggerFactory.getLogger(PersistentEventWriter::class.java)
 
     init {
-        GlobalScope.launch {
+        thread {
             syncLoop()
         }
     }
 
-    override fun send(eventInput: EventInput) {
+    override fun sendAsync(eventInput: EventInput) {
         GlobalScope.launch {
             localEventCache.storeEvent(eventInput)
         }
     }
 
-    override suspend fun sendAndWaitForAck(eventInput: EventInput): Boolean {
+    override fun send(eventInput: EventInput): Boolean {
+        return runBlocking { sendAndWaitForAck(eventInput) }
+    }
+
+    private suspend fun sendAndWaitForAck(eventInput: EventInput): Boolean {
         return try {
             localEventCache.storeEvent(eventInput)
             true
@@ -39,19 +43,18 @@ internal class PersistentEventWriter(
         }
     }
 
-    private suspend fun syncLoop() {
+    private fun syncLoop() {
+        val queue = localEventCache.getPendingEventQueue()
         while (true) {
-            localEventCache.getAllUndelivered().forEach {
-                try {
-                    log.trace("Sending event to event ${it.topic}/${it.uuid} to backend")
-                    eventEngine.send(it)
-                    localEventCache.markAsDelivered(it.id)
-                } catch (ex: Exception) {
-                    log.error("Event sync failed${ex.message}")
-                    ex.printStackTrace()
-                }
+            try {
+                val item = queue.take()
+                log.trace("Sending event to event ${item.topic}/${item.uuid} to backend")
+                eventEngine.send(item)
+                localEventCache.markAsDelivered(item.id)
+            } catch (ex: Exception) {
+                log.error("Event sync failed${ex.message}")
+                ex.printStackTrace()
             }
-            delay(loopDelay)
         }
     }
 }

--- a/src/main/kotlin/mobi/waterdog/eventbus/persistence/PersistentEventWriter.kt
+++ b/src/main/kotlin/mobi/waterdog/eventbus/persistence/PersistentEventWriter.kt
@@ -43,7 +43,7 @@ internal class PersistentEventWriter(
         while (true) {
             localEventCache.getAllUndelivered().forEach {
                 try {
-                    log.debug("Sending event to event ${it.topic}/${it.uuid} to backend")
+                    log.trace("Sending event to event ${it.topic}/${it.uuid} to backend")
                     eventEngine.send(it)
                     localEventCache.markAsDelivered(it.id)
                 } catch (ex: Exception) {

--- a/src/main/kotlin/mobi/waterdog/eventbus/persistence/sql/EventTableMappings.kt
+++ b/src/main/kotlin/mobi/waterdog/eventbus/persistence/sql/EventTableMappings.kt
@@ -31,14 +31,13 @@ internal class EventDAO(id: EntityID<Long>) : LongEntity(id) {
     var payload by EventTable.payload
 
     fun toFullModel(): Event {
-        val sendTs = if (sendTimestamp != null) Instant.parse(sendTimestamp) else null
         return Event(
             id.value,
             delivered,
             topic,
             uuid,
             Instant.parse(storedTimestamp),
-            sendTs,
+            sendTimestamp?.let { Instant.parse(sendTimestamp) },
             msgType,
             mimeType,
             payload.binaryStream.readBytes()

--- a/src/main/kotlin/mobi/waterdog/eventbus/persistence/sql/EventTableMappings.kt
+++ b/src/main/kotlin/mobi/waterdog/eventbus/persistence/sql/EventTableMappings.kt
@@ -11,7 +11,8 @@ internal object EventTable : LongIdTable("recorded_events") {
     val topic = varchar("topic", 255)
     val delivered = bool("delivered")
     val uuid = varchar("uuid", 36).uniqueIndex()
-    val sendTimestamp = varchar("send_timestamp", 24)
+    val storedTimestamp = varchar("stored_timestamp", 24)
+    val sendTimestamp = varchar("send_timestamp", 24).nullable()
     val msgType = varchar("msgType", 255)
     val mimeType = varchar("mimeType", 255)
     val payload = blob("payload")
@@ -23,18 +24,21 @@ internal class EventDAO(id: EntityID<Long>) : LongEntity(id) {
     var topic by EventTable.topic
     var delivered by EventTable.delivered
     var uuid by EventTable.uuid
+    var storedTimestamp by EventTable.storedTimestamp
     var sendTimestamp by EventTable.sendTimestamp
     var msgType by EventTable.msgType
     var mimeType by EventTable.mimeType
     var payload by EventTable.payload
 
     fun toFullModel(): Event {
+        val sendTs = if (sendTimestamp != null) Instant.parse(sendTimestamp) else null
         return Event(
             id.value,
             delivered,
             topic,
             uuid,
-            Instant.parse(sendTimestamp),
+            Instant.parse(storedTimestamp),
+            sendTs,
             msgType,
             mimeType,
             payload.binaryStream.readBytes()

--- a/src/main/kotlin/mobi/waterdog/eventbus/persistence/sql/LocalEventCacheSql.kt
+++ b/src/main/kotlin/mobi/waterdog/eventbus/persistence/sql/LocalEventCacheSql.kt
@@ -1,30 +1,36 @@
 package mobi.waterdog.eventbus.persistence.sql
 
+import kotlinx.coroutines.experimental.runBlocking
 import mobi.waterdog.eventbus.model.Event
 import mobi.waterdog.eventbus.model.EventInput
 import mobi.waterdog.eventbus.persistence.LocalEventCache
 import java.time.Instant
 import java.util.UUID
+import java.util.concurrent.BlockingQueue
+import java.util.concurrent.LinkedBlockingQueue
 import javax.sql.rowset.serial.SerialBlob
 
 internal class LocalEventCacheSql(private val databaseConnection: DatabaseConnection) : LocalEventCache {
-    override suspend fun markAsDelivered(eventId: Long) {
-        databaseConnection.query {
-            val event = EventDAO[eventId]
-            event.delivered = true
-            event.sendTimestamp = Instant.now().toString()
+
+    private val pendingEvents: BlockingQueue<Event> = LinkedBlockingQueue()
+
+    override fun markAsDelivered(eventId: Long) {
+        runBlocking {
+            databaseConnection.query {
+                val event = EventDAO[eventId]
+                event.delivered = true
+                event.sendTimestamp = Instant.now().toString()
+            }
         }
     }
 
-    override suspend fun getAllUndelivered(): List<Event> {
-        return databaseConnection.query {
-            EventDAO.find { EventTable.delivered eq false }.map { it.toFullModel() }
-        }.sortedBy { EventTable.storedTimestamp }
+    override fun getPendingEventQueue(): BlockingQueue<Event> {
+        return pendingEvents
     }
 
     override suspend fun storeEvent(eventInput: EventInput): Event {
         return databaseConnection.query {
-            EventDAO.new {
+            val evt = EventDAO.new {
                 topic = eventInput.topic
                 delivered = false
                 uuid = UUID.randomUUID().toString()
@@ -33,6 +39,9 @@ internal class LocalEventCacheSql(private val databaseConnection: DatabaseConnec
                 mimeType = eventInput.mimeType
                 payload = SerialBlob(eventInput.payload)
             }.toFullModel()
+
+            this.pendingEvents.put(evt)
+            evt
         }
     }
 }

--- a/src/test/kotlin/mobi/waterdog/eventbus/EventBusTest.kt
+++ b/src/test/kotlin/mobi/waterdog/eventbus/EventBusTest.kt
@@ -80,7 +80,7 @@ class EventBusTest : KoinTest {
                 "application/json",
                 jsonMsg.toByteArray()
             )
-            eventProducer.send(event)
+            eventProducer.sendAsync(event)
         }
     }
 
@@ -106,7 +106,7 @@ class EventBusTest : KoinTest {
                     "application/json",
                     jsonMsg.toByteArray()
                 )
-                val result = eventProducer.sendAndWaitForAck(event)
+                val result = eventProducer.send(event)
                 result.`should be true`()
             }
             delay(500)


### PR DESCRIPTION
Fixes #3: Updated the PersistentEventWriter so that events are sorted in ascending order by their storeTimestap. Added a new timestamp to keep track of when the events are sent to the messa